### PR TITLE
Link to sveltekit example at its correct url

### DIFF
--- a/apps/docs/src/content/docs/guides/examples.mdx
+++ b/apps/docs/src/content/docs/guides/examples.mdx
@@ -12,12 +12,12 @@ Navigate between framework examples, a [GitHub Actions](https://github.com/zugri
 | :----------- | :----------------------------------------------------------------------------------------------- | :---------------------------------- |
 | Static       | [./apps/example-static/](https://github.com/zugriffcloud/examples/blob/main/apps/example-static) | https://static.examples.zugriff.app |
 
-| Framework | Example                                                                                                | View                                |
-| :-------- | :----------------------------------------------------------------------------------------------------- | :---------------------------------- |
-| Astro     | [./apps/example-astro/](https://github.com/zugriffcloud/examples/blob/main/apps/example-astro)         | https://astro.examples.zugriff.app  |
-| Hono      | [./apps/example-hono/](https://github.com/zugriffcloud/examples/blob/main/apps/example-hono)           | https://hono.examples.zugriff.app   |
-| Next.js   | [./apps/example-nextjs/](https://github.com/zugriffcloud/examples/blob/main/apps/example-nextjs)       | https://next.examples.zugriff.app   |
-| Nuxt      | [./apps/example-nuxt/](https://github.com/zugriffcloud/examples/blob/main/apps/example-nuxt)           | https://nuxt.examples.zugriff.app   |
-| Remix     | [./apps/example-remix/](https://github.com/zugriffcloud/examples/blob/main/apps/example-remix)         | https://remix.examples.zugriff.app  |
-| Solid     | [./apps/example-solid/](https://github.com/zugriffcloud/examples/blob/main/apps/example-solid)         | https://solid.examples.zugriff.app  |
-| SvelteKit | [./apps/example-sveltekit/](https://github.com/zugriffcloud/examples/blob/main/apps/example-sveltekit) | https://svelte.examples.zugriff.app |
+| Framework | Example                                                                                                | View                                   |
+| :-------- | :----------------------------------------------------------------------------------------------------- | :------------------------------------- |
+| Astro     | [./apps/example-astro/](https://github.com/zugriffcloud/examples/blob/main/apps/example-astro)         | https://astro.examples.zugriff.app     |
+| Hono      | [./apps/example-hono/](https://github.com/zugriffcloud/examples/blob/main/apps/example-hono)           | https://hono.examples.zugriff.app      |
+| Next.js   | [./apps/example-nextjs/](https://github.com/zugriffcloud/examples/blob/main/apps/example-nextjs)       | https://next.examples.zugriff.app      |
+| Nuxt      | [./apps/example-nuxt/](https://github.com/zugriffcloud/examples/blob/main/apps/example-nuxt)           | https://nuxt.examples.zugriff.app      |
+| Remix     | [./apps/example-remix/](https://github.com/zugriffcloud/examples/blob/main/apps/example-remix)         | https://remix.examples.zugriff.app     |
+| Solid     | [./apps/example-solid/](https://github.com/zugriffcloud/examples/blob/main/apps/example-solid)         | https://solid.examples.zugriff.app     |
+| SvelteKit | [./apps/example-sveltekit/](https://github.com/zugriffcloud/examples/blob/main/apps/example-sveltekit) | https://sveltekit.examples.zugriff.app |


### PR DESCRIPTION
The new url matches the one given in https://github.com/zugriffcloud/examples